### PR TITLE
Add ETag to cached CacheRequest

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/etag/CacheRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/etag/CacheRequest.java
@@ -163,20 +163,16 @@ public class CacheRequest extends HttpRequest {
    * Get the eTag for request
    *
    * <p>
-   * If this request returned http code 304, this eTag value is based on
-   * the cached value available in the EtagCache. Otherwise, this
-   * value is read from the HttpRequest object
+   * If the http response includes an ETag that tag will
+   * always be used. If it does not include an ETag, the ETag will
+   * be restored from the cache
    */
   @Override
   public String eTag() {
-    final int rawCode = super.code();
-    if (rawCode == HTTP_NOT_MODIFIED && response != null) {
-      return response.eTag;
-    }
-    else
-    {
-      return super.eTag();
-    }
+    String tag = super.eTag();
+    if (tag == null && response != null)
+      tag = response.eTag;
+    return tag;
   }
 
   /**

--- a/lib/src/main/java/com/github/kevinsawicki/etag/CacheRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/etag/CacheRequest.java
@@ -160,6 +160,26 @@ public class CacheRequest extends HttpRequest {
   }
 
   /**
+   * Get the eTag for request
+   *
+   * <p>
+   * If this request returned http code 304, this eTag value is based on
+   * the cached value available in the EtagCache. Otherwise, this
+   * value is read from the HttpRequest object
+   */
+  @Override
+  public String eTag() {
+    final int rawCode = super.code();
+    if (rawCode == HTTP_NOT_MODIFIED && response != null) {
+      return response.eTag;
+    }
+    else
+    {
+      return super.eTag();
+    }
+  }
+
+  /**
    * Get the input stream for this request.
    * <p>
    * The streams returned by this method will always auto-uncompress any gzip'ed


### PR DESCRIPTION
When retrieving CacheRequest from the local cache, the eTag() method
would return null instead of returning the eTag associated with the
cached response. This change modifies the eTag method to return
HttpRequest.eTag() when the response is not 304, and response.etag when
it is.
